### PR TITLE
[Design/#21] 레이아웃 margin 추가

### DIFF
--- a/src/app/(layout)/advice/page.tsx
+++ b/src/app/(layout)/advice/page.tsx
@@ -1,3 +1,3 @@
-export default function TestPage() {
+export default function Advice() {
   return;
 }

--- a/src/components/ui/Footer/index.tsx
+++ b/src/components/ui/Footer/index.tsx
@@ -2,7 +2,7 @@ import Logo from '@/assets/logo.svg';
 
 export default function Footer() {
   return (
-    <footer className="bg-layout-grey1 mx-auto flex min-w-screen items-center justify-between px-24 pt-6 pb-[42px]">
+    <footer className="bg-layout-grey1 mx-auto mt-[140px] flex min-w-screen items-center justify-between px-24 pt-6 pb-[42px]">
       <div className="flex flex-col">
         <Logo />
         <p className="detail text-layout-grey6">Copyright(c)2025</p>

--- a/src/components/ui/Header/index.tsx
+++ b/src/components/ui/Header/index.tsx
@@ -21,7 +21,7 @@ export default function Header() {
   const isLogin = true;
 
   return (
-    <header className="bg-layout-grey1 mx-auto flex min-w-screen items-center justify-between px-24 py-3">
+    <header className="bg-layout-grey1 mx-auto mb-[100px] flex min-w-screen items-center justify-between px-24 py-3">
       <section className="flex h-11 items-center gap-[110px]">
         <Link href="/">
           <Logo />


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #21 

## ✏️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Check List

- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🏗️ yarn build는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요? (TODO, 주석, clg... etc.)
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요?

## ✨ Key Changes

1. 레이아웃 상/하단에 마진값 적용

## 📢 To Reviewers

- 기존에 푸터 헤더만 있었는데, 푸터 위에 140px, 헤더 하단에 100px 마진이 고정값이라고 해서 추가했습니다!
- 변경사항이 크지 않기도 하고 바로 사용해서 리뷰 없이 머지하겠습니다!