### PR TITLE
[Feat/#81] 회원가입/로그인 API 연결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,6 @@
 import type { NextConfig } from 'next';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URI;
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@svgr/cli": "^8.1.0",
     "@tanstack/react-query": "^5.75.5",
     "clsx": "^2.1.1",
+    "js-base64": "^3.7.7",
     "next": "15.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/app/(auth)/@content/login/page.tsx
+++ b/src/app/(auth)/@content/login/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Spacing } from '@/components/ui/Spacing';
 import Logo from '@/assets/logo.svg';
 import IconKaKao from '@/assets/icons/icon-kakao.svg';
@@ -14,11 +16,21 @@ export default function LoginPage() {
       <Spacing size={120} />
       <section className="flex flex-col gap-3">
         {/* TODO : api 연결할 때 onClick 연결 필요 */}
-        <button className="flex h-[45px] w-[300px] items-center justify-center rounded-md bg-[#fee500] p-[14px]">
+        <button
+          onClick={() => {
+            window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URI}/oauth2/authorization/kakao`;
+          }}
+          className="flex h-[45px] w-[300px] items-center justify-center rounded-md bg-[#fee500] p-[14px]"
+        >
           <IconKaKao />
           <KakaoText />
         </button>
-        <button className="border-layout-grey4 flex h-[45px] w-[300px] items-center justify-center rounded-md border p-[14px]">
+        <button
+          onClick={() => {
+            window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URI}/oauth2/authorization/google`;
+          }}
+          className="border-layout-grey4 flex h-[45px] w-[300px] items-center justify-center rounded-md border p-[14px]"
+        >
           <IconGoogle />
           <GoogleText />
         </button>

--- a/src/app/(auth)/@content/sign-up/step3/page.tsx
+++ b/src/app/(auth)/@content/sign-up/step3/page.tsx
@@ -6,6 +6,7 @@ import { Spacing } from '@/components/ui/Spacing';
 import { Button } from '@/components/ui/Button';
 import { StepBar } from '@/components/ui/StepBar';
 import { useSignupStore } from '@/stores/signUpStore';
+import { useSignUp } from '@/hooks/users/useSignUp';
 import IconArrowDown from '@/assets/icons/icon-arrow-down.svg';
 import IconArrowBack from '@/assets/icons/icon-arrow-back.svg';
 
@@ -35,7 +36,8 @@ const category = [
 
 export default function Step1() {
   const router = useRouter();
-  const { preferences, setPreferences, clearPreferences } = useSignupStore();
+  const { username, role, preferences, setPreferences, clearPreferences } = useSignupStore();
+  const { mutate: signUp } = useSignUp();
 
   const [currentIndex, setCurrentIndex] = useState(0);
 
@@ -50,6 +52,14 @@ export default function Step1() {
 
   const handleNextBtn = () => {
     router.push('/sign-up-complete');
+  };
+
+  const handleSignUp = () => {
+    signUp({
+      name: username,
+      job: role,
+      tags: preferences,
+    });
   };
 
   return (
@@ -111,11 +121,24 @@ export default function Step1() {
       </div>
       <Spacing size={40} />
       <div className="flex w-full justify-between">
-        <Button size="small" state="line" onClick={handleSkipBtn}>
+        <Button
+          size="small"
+          state="line"
+          onClick={() => {
+            handleSkipBtn();
+            handleSignUp();
+          }}
+        >
           건너뛰기
         </Button>
         {preferences.length >= 3 ? (
-          <Button size="small" onClick={handleNextBtn}>
+          <Button
+            size="small"
+            onClick={() => {
+              handleNextBtn();
+              handleSignUp();
+            }}
+          >
             다음으로
           </Button>
         ) : (

--- a/src/app/(auth)/callback/page.tsx
+++ b/src/app/(auth)/callback/page.tsx
@@ -1,0 +1,3 @@
+export default function CallbackPage() {
+  return <div>콜백 페이지</div>;
+}

--- a/src/app/(auth)/callback/page.tsx
+++ b/src/app/(auth)/callback/page.tsx
@@ -1,3 +1,0 @@
-export default function CallbackPage() {
-  return <div>콜백 페이지</div>;
-}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,16 +1,22 @@
 import { ReactNode } from 'react';
 
 type Props = {
+  children: ReactNode;
   image: ReactNode;
   content: ReactNode;
 };
 
-export default function AuthLayout({ content, image }: Props) {
+export default function AuthLayout({ children, content, image }: Props) {
   return (
     <div className="flex min-h-screen">
-      <div className="flex w-1/2 items-center justify-center">{content}</div>
-
-      <div className="relative w-1/2">{image}</div>
+      {children ? (
+        <div className="flex w-full items-center justify-center">{children}</div>
+      ) : (
+        <>
+          <div className="flex w-1/2 items-center justify-center">{content}</div>
+          <div className="relative w-1/2">{image}</div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,22 +1,15 @@
 import { ReactNode } from 'react';
 
 type Props = {
-  children: ReactNode;
   image: ReactNode;
   content: ReactNode;
 };
 
-export default function AuthLayout({ children, content, image }: Props) {
+export default function AuthLayout({ content, image }: Props) {
   return (
     <div className="flex min-h-screen">
-      {children ? (
-        <div className="flex w-full items-center justify-center">{children}</div>
-      ) : (
-        <>
-          <div className="flex w-1/2 items-center justify-center">{content}</div>
-          <div className="relative w-1/2">{image}</div>
-        </>
-      )}
+      <div className="flex w-1/2 items-center justify-center">{content}</div>
+      <div className="relative w-1/2">{image}</div>
     </div>
   );
 }

--- a/src/app/callback/page.tsx
+++ b/src/app/callback/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, Suspense } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { handleLoginSuccess } from '@/utils/loginHandler';
+
+function CallbackContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  useEffect(() => {
+    const type = searchParams.get('type');
+    const accessToken = searchParams.get('token');
+
+    switch (type) {
+      case 'NEW_USER':
+        router.replace('/sign-up/step1');
+        break;
+      case 'SUCCESS':
+      default:
+        handleLoginSuccess(accessToken);
+        router.replace('/advice');
+        break;
+    }
+  }, [searchParams, router]);
+
+  return <p>Redirecting...</p>;
+}
+
+export default function Callback() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <CallbackContent />
+    </Suspense>
+  );
+}

--- a/src/components/ui/Header/index.tsx
+++ b/src/components/ui/Header/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
@@ -8,6 +9,7 @@ import Logo from '@/assets/logo.svg';
 
 export default function Header() {
   const pathname = usePathname();
+  const [isLogin, setIsLogin] = useState(false);
 
   const menus = [
     { label: '조언받기', href: '/advice' },
@@ -15,10 +17,11 @@ export default function Header() {
     { label: '보관함', href: '/archive' },
   ];
 
-  {
-    /* TODO : 쿠키에서 로그인 여부 받아서 수정할 수 있도록 하기 */
-  }
-  const isLogin = true;
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    const user = localStorage.getItem('user');
+    setIsLogin(!!(token && user));
+  }, []);
 
   return (
     <header className="bg-layout-grey1 mx-auto mb-[100px] flex min-w-screen items-center justify-between px-24 py-3">
@@ -29,7 +32,6 @@ export default function Header() {
         <nav className="flex gap-20">
           {menus.map((menu) => {
             const isActive = pathname.startsWith(menu.href);
-
             return (
               <Link
                 key={menu.href}
@@ -51,7 +53,6 @@ export default function Header() {
           <Button
             variant="grey"
             size="small"
-            // TODO : 로그아웃 연결
             onClick={() => {
               alert('로그아웃!');
             }}

--- a/src/hooks/users/useSignUp.ts
+++ b/src/hooks/users/useSignUp.ts
@@ -1,0 +1,7 @@
+import { SignupRequest, userSignUp } from '@/services/users/postSignUp';
+import { useMutation } from '@tanstack/react-query';
+
+export const useSignUp = () =>
+  useMutation<void, Error, SignupRequest>({
+    mutationFn: (data) => userSignUp(data),
+  });

--- a/src/services/users/postSignUp.ts
+++ b/src/services/users/postSignUp.ts
@@ -1,0 +1,14 @@
+import { customFetch } from '@/utils/customFetch';
+
+export interface SignupRequest {
+  name: string;
+  job: string;
+  tags: string[];
+}
+
+export const userSignUp = async (payload: SignupRequest): Promise<void> => {
+  return customFetch('/users/sign-up', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+};

--- a/src/utils/loginHandler.ts
+++ b/src/utils/loginHandler.ts
@@ -1,0 +1,15 @@
+import { decode } from 'js-base64';
+
+export const handleLoginSuccess = (accessToken: string | null) => {
+  if (accessToken) {
+    const payload = accessToken.split('.')[1] || '';
+    const decodedPayload = decode(payload);
+    const payloadObject = JSON.parse(decodedPayload);
+    const { name: tokenName } = payloadObject;
+
+    const userInfo = { name: tokenName };
+
+    localStorage.setItem('token', accessToken);
+    localStorage.setItem('user', JSON.stringify(userInfo));
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3876,6 +3876,7 @@ __metadata:
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     husky: "npm:^9.1.7"
+    js-base64: "npm:^3.7.7"
     lint-staged: "npm:^15.5.0"
     next: "npm:15.2.4"
     postcss: "npm:^8.5.3"
@@ -4561,6 +4562,13 @@ __metadata:
   bin:
     jiti: lib/jiti-cli.mjs
   checksum: 10c0/4ceac133a08c8faff7eac84aabb917e85e8257f5ad659e843004ce76e981c457c390a220881748ac67ba1b940b9b729b30fb85cbaf6e7989f04b6002c94da331
+  languageName: node
+  linkType: hard
+
+"js-base64@npm:^3.7.7":
+  version: 3.7.7
+  resolution: "js-base64@npm:3.7.7"
+  checksum: 10c0/3c905a7e78b601e4751b5e710edd0d6d045ce2d23eb84c9df03515371e1b291edc72808dc91e081cb9855aef6758292a2407006f4608ec3705373dd8baf2f80f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #81 

## ✏️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Check List

- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🏗️ yarn build는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요? (TODO, 주석, clg... etc.)
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요?

## ✨ Key Changes

1. 카카오 로그인 연결
2. 구글 로그인 연결
3. 회원가입/로그인 분기처리
5. 헤더 분기 처리

## 📢 To Reviewers

- 회원가입 시 step3에서 API 요청하도록 해두었습니다!
- 테스트 시 callback 페이지에서 `geulowup.site`를 로컬로 변경해서 확인하시면 돼요! 
- 로그인에 따라 분기처리 해야 하는 부분 브랜치 따로 파서 작업하겠습니다.

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/1e8a2ee8-a76b-442d-91e5-21317fdbe266)

