### PR TITLE
[Bug/#90] small 카드 hover 시 전체 텍스트 보이도록 수정

### DIFF
--- a/src/components/ui/Card/index.tsx
+++ b/src/components/ui/Card/index.tsx
@@ -84,6 +84,13 @@ const Card: React.FC<CardProps> = ({
       const element = descriptionRef.current;
       if (!element) return;
 
+      // hover 상태에서는 원본 텍스트를 보여줌
+      if (variant === 'small' && state === 'hover') {
+        setTruncatedDescription(description);
+        element.textContent = description; // DOM에도 원본 텍스트 반영
+        return;
+      }
+
       // 원래 텍스트로 초기화
       element.textContent = description;
 
@@ -153,7 +160,12 @@ const Card: React.FC<CardProps> = ({
             ref={descriptionRef}
             className="body-sm text-layout-grey6 mb-[16px]"
             style={{
-              maxHeight: variant === 'small' && state !== 'hover' ? '44px' : 'calc(1.5em * 3)',
+              maxHeight:
+                variant === 'small' && state !== 'hover'
+                  ? '44px'
+                  : variant === 'small' && state === 'hover'
+                    ? 'none'
+                    : 'calc(1.5em * 3)',
               overflow: 'hidden',
             }}
           >


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #90 

## ✏️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Check List

- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🏗️ yarn build는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요? (TODO, 주석, clg... etc.)
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요?

## ✨ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers

small 카드 hover 했을때 여전히 생략된 텍스트로 표기하고 있는 증상 전체 텍스트 표기하도록 수정했습니다. 

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
수정 전
![image](https://github.com/user-attachments/assets/b57dd184-a311-4f44-b051-af8786222ac3)

수정 후
![image](https://github.com/user-attachments/assets/32da235c-25e2-4b59-8f58-c84e5e5d2e2e)

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
